### PR TITLE
[FT01] Caching: Repositories And Its Caches Implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "dependencies": {
     "axios": "^1.6.0",
+    "cache-manager": "^6.3.1",
     "deepl-node": "^1.14.0",
     "discord.js": "^14.16.3",
     "dotenv": "^16.4.5",

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,4 +2,7 @@ export * from './mongodb/models//ChannelLink';
 export * from './mongodb/models/GuildKey';
 export * from './mongodb/models/MessageLink';
 export * from './mongodb/models/TranslateChannel';
+export * from './mongodb/Channel';
+export * from './mongodb/Guild';
+export * from './mongodb/Message';
 export * from './mongodb/connect';

--- a/packages/db/src/mongodb/Channel.ts
+++ b/packages/db/src/mongodb/Channel.ts
@@ -1,0 +1,59 @@
+import mongoose from 'mongoose';
+import { Channel, ChannelLanguage } from '@zekuru-v2/entities';
+
+const ChannelLanguageSchema = new mongoose.Schema<ChannelLanguage>(
+  {
+    name: {
+      type: String,
+      required: true,
+      lowercase: true,
+    },
+    codes: {
+      type: [String],
+      required: true,
+      lowercase: true,
+      default: [],
+    },
+  },
+  { _id: false }
+);
+
+const ChannelSchema = new mongoose.Schema<Channel>({
+  _id: {
+    type: String,
+    required: true,
+    immutable: true,
+  },
+  guildId: {
+    type: String,
+    required: true,
+  },
+  links: {
+    type: [String],
+    default: [],
+  },
+  language: {
+    type: ChannelLanguageSchema,
+    required: true,
+  },
+  createdBy: {
+    type: String,
+    required: true,
+  },
+  createdAt: {
+    type: Date,
+    immutable: true,
+    default: Date.now,
+  },
+  modifiedBy: {
+    type: String,
+    required: true,
+  },
+  modifiedAt: {
+    type: Date,
+    required: true,
+    default: Date.now,
+  },
+});
+
+export default mongoose.model<Channel>('Channel', ChannelSchema);

--- a/packages/db/src/mongodb/Channel.ts
+++ b/packages/db/src/mongodb/Channel.ts
@@ -56,4 +56,4 @@ const ChannelSchema = new mongoose.Schema<Channel>({
   },
 });
 
-export default mongoose.model<Channel>('Channel', ChannelSchema);
+export const ChannelModel = mongoose.model<Channel>('Channel', ChannelSchema);

--- a/packages/db/src/mongodb/Guild.ts
+++ b/packages/db/src/mongodb/Guild.ts
@@ -1,0 +1,106 @@
+import {
+  CommonCredential,
+  DeepLCredential,
+  Guild,
+  GuildTranslationMeta,
+  OpenAICredential,
+} from '@zekuru-v2/entities';
+import mongoose from 'mongoose';
+
+const CredentialSchema = new mongoose.Schema<CommonCredential>(
+  {
+    createdBy: {
+      type: String,
+      required: true,
+    },
+    createdAt: {
+      type: Date,
+      immutable: true,
+      default: Date.now,
+    },
+  },
+  { _id: false }
+);
+
+const TranslationSchema = new mongoose.Schema<GuildTranslationMeta>(
+  {
+    credentials: {
+      type: [CredentialSchema],
+      required: true,
+      default: [],
+    },
+  },
+  { _id: false }
+);
+
+const translationDocArray =
+  TranslationSchema.path<mongoose.Schema.Types.DocumentArray>('credentials');
+
+translationDocArray.discriminator(
+  'deepl',
+  new mongoose.Schema<Omit<DeepLCredential, keyof CommonCredential>>(
+    {
+      apiKey: {
+        type: String,
+        required: true,
+      },
+      type: {
+        type: String,
+        immutable: true,
+        default: 'deepl',
+      },
+    },
+    { _id: false }
+  )
+);
+
+translationDocArray.discriminator(
+  'openai',
+  new mongoose.Schema<Omit<OpenAICredential, keyof CommonCredential>>(
+    {
+      apiKey: {
+        type: String,
+        required: true,
+      },
+      type: {
+        type: String,
+        immutable: true,
+        default: 'openai',
+      },
+    },
+    { _id: false }
+  )
+);
+
+const GuildSchema = new mongoose.Schema<Guild>({
+  _id: {
+    type: String,
+    required: true,
+    immutable: true,
+  },
+  translation: {
+    type: TranslationSchema,
+    required: true,
+    default: {},
+  },
+  createdBy: {
+    type: String,
+    required: true,
+  },
+  createdAt: {
+    type: Date,
+    immutable: true,
+    default: Date.now,
+  },
+  modifiedBy: {
+    type: String,
+    required: true,
+  },
+  modifiedAt: {
+    type: Date,
+    required: true,
+    default: Date.now,
+  },
+});
+
+export default mongoose.model<Guild>('Guild', GuildSchema);

--- a/packages/db/src/mongodb/Guild.ts
+++ b/packages/db/src/mongodb/Guild.ts
@@ -103,4 +103,4 @@ const GuildSchema = new mongoose.Schema<Guild>({
   },
 });
 
-export default mongoose.model<Guild>('Guild', GuildSchema);
+export const GuildModel = mongoose.model<Guild>('Guild', GuildSchema);

--- a/packages/db/src/mongodb/Message.ts
+++ b/packages/db/src/mongodb/Message.ts
@@ -1,0 +1,37 @@
+import { Message } from '@zekuru-v2/entities';
+import mongoose from 'mongoose';
+
+const MessageSchema = new mongoose.Schema<Message>({
+  _id: {
+    type: String,
+    required: true,
+    immutable: true,
+  },
+  authorId: {
+    type: String,
+    required: true,
+    immutable: true,
+  },
+  guildId: {
+    type: String,
+    required: true,
+    immutable: true,
+  },
+  channelId: {
+    type: String,
+    required: true,
+    immutable: true,
+  },
+  linkId: {
+    type: String,
+    required: true,
+    immutable: true,
+  },
+  createdAt: {
+    type: Date,
+    immutable: true,
+    default: Date.now,
+  },
+});
+
+export default mongoose.model<Message>('Message', MessageSchema);

--- a/packages/db/src/mongodb/Message.ts
+++ b/packages/db/src/mongodb/Message.ts
@@ -34,4 +34,4 @@ const MessageSchema = new mongoose.Schema<Message>({
   },
 });
 
-export default mongoose.model<Message>('Message', MessageSchema);
+export const MessageModel = mongoose.model<Message>('Message', MessageSchema);

--- a/packages/entities/src/Common.ts
+++ b/packages/entities/src/Common.ts
@@ -1,8 +1,11 @@
 import { Snowflake } from '@zekuru-v2/types';
 
-export interface CommonEntity {
+export interface Createable {
   createdAt: Date;
   createdBy: Snowflake;
+}
+
+export interface Modifiable {
   modifiedAt: Date;
   modifiedBy: Snowflake;
 }

--- a/packages/entities/src/channel/Channel.ts
+++ b/packages/entities/src/channel/Channel.ts
@@ -1,8 +1,8 @@
 import { Snowflake } from '@zekuru-v2/types';
-import { CommonEntity } from '../CommonEntity';
+import { Createable, Modifiable } from '../Common';
 import { ChannelLanguage } from './ChannelLanguage';
 
-export class Channel implements CommonEntity {
+export class Channel implements Createable, Modifiable {
   constructor(
     public _id: Snowflake,
     public guildId: Snowflake,

--- a/packages/entities/src/channel/index.ts
+++ b/packages/entities/src/channel/index.ts
@@ -1,0 +1,2 @@
+export * from './Channel';
+export * from './ChannelLanguage';

--- a/packages/entities/src/guild/CommonCredential.ts
+++ b/packages/entities/src/guild/CommonCredential.ts
@@ -1,6 +1,4 @@
-import { Snowflake } from '@zekuru-v2/types';
+import { Createable } from '../Common';
 
-export interface CommonCredential {
-  addedAt: Date;
-  addedBy: Snowflake;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
+export interface CommonCredential extends Createable {}

--- a/packages/entities/src/guild/Guild.ts
+++ b/packages/entities/src/guild/Guild.ts
@@ -1,8 +1,8 @@
 import { Snowflake } from '@zekuru-v2/types';
-import { CommonEntity } from '../CommonEntity';
 import { GuildTranslationMeta } from './GuildTranslationMeta';
+import { Createable, Modifiable } from '../Common';
 
-export class Guild implements CommonEntity {
+export class Guild implements Createable, Modifiable {
   constructor(
     public _id: Snowflake,
     public translation: GuildTranslationMeta,

--- a/packages/entities/src/guild/index.ts
+++ b/packages/entities/src/guild/index.ts
@@ -1,0 +1,5 @@
+export * from './CommonCredential';
+export * from './DeepLCredential';
+export * from './OpenAICredential';
+export * from './GuildTranslationMeta';
+export * from './Guild';

--- a/packages/entities/src/index.ts
+++ b/packages/entities/src/index.ts
@@ -1,3 +1,3 @@
-export * from './channel/Channel';
-export * from './guild/Guild';
-export * from './message/Message';
+export * from './channel';
+export * from './guild';
+export * from './message';

--- a/packages/entities/src/message/Message.ts
+++ b/packages/entities/src/message/Message.ts
@@ -1,15 +1,12 @@
 import { Snowflake } from '@zekuru-v2/types';
-import { CommonEntity } from '../CommonEntity';
 
-export class Message implements CommonEntity {
+export class Message {
   constructor(
     public _id: Snowflake,
     public authorId: Snowflake,
     public channelId: Snowflake,
     public guildId: Snowflake,
-    public createdAt: Date,
-    public createdBy: Snowflake,
-    public modifiedAt: Date,
-    public modifiedBy: Snowflake
+    public linkId: Snowflake,
+    public createdAt: Date
   ) {}
 }

--- a/packages/entities/src/message/index.ts
+++ b/packages/entities/src/message/index.ts
@@ -1,0 +1,1 @@
+export * from './Message';

--- a/packages/repositories/src/BaseMongoRepository.ts
+++ b/packages/repositories/src/BaseMongoRepository.ts
@@ -1,0 +1,77 @@
+import { Snowflake } from 'discord.js';
+import { HydratedDocument, Model } from 'mongoose';
+import { CommonRepository } from './CommonRepository';
+
+export abstract class BaseMongoRepository<T> implements CommonRepository<T> {
+  constructor(private model: Model<T>) {}
+
+  private getId(entity: Partial<T>): string {
+    return (entity as unknown as { _id: string })._id;
+  }
+
+  async insertOne(entity: T): Promise<T> {
+    const instance = new this.model(entity);
+    await instance.save();
+    return instance;
+  }
+
+  async insertMany(entities: T[]): Promise<T[]> {
+    const instances = await this.model.insertMany(entities);
+    return instances;
+  }
+
+  async findById(id: Snowflake): Promise<T | null> {
+    const instance = await this.model.findById(id);
+    if (!instance) return null;
+    return instance;
+  }
+
+  async findByIds(ids: Snowflake[]): Promise<T[]> {
+    const instances = await this.model.find().where('_id').in(ids);
+    return instances;
+  }
+
+  async updateOne(entity: Partial<T>): Promise<T> {
+    if (entity instanceof this.model) {
+      await entity.save();
+      return entity;
+    }
+
+    const instance = await this.model.findByIdAndUpdate(
+      this.getId(entity),
+      entity,
+      {
+        returnOriginal: false,
+      }
+    );
+    return instance;
+  }
+
+  async updateMany(entities: Partial<T>[]): Promise<T[]> {
+    const map = new Map(entities.map((entity) => [this.getId(entity), entity]));
+    const oldInstances = (await this.findByIds([
+      ...map.keys(),
+    ])) as HydratedDocument<T>[];
+
+    // validate first before updating
+    const instances = await Promise.all(
+      oldInstances.map(async (instance) => {
+        instance.set(map.get(this.getId(instance)));
+        await instance.validate();
+        return instance;
+      })
+    );
+
+    return (await Promise.all(
+      instances.map(async (instance) => await instance.save())
+    )) as T[];
+  }
+
+  async deleteById(id: Snowflake): Promise<void> {
+    await this.model.deleteOne().where('_id').equals(id);
+  }
+
+  async deleteManyByIds(ids: Snowflake[]): Promise<void> {
+    await this.model.deleteMany().where('_id').in(ids);
+  }
+}

--- a/packages/repositories/src/CommonRepository.ts
+++ b/packages/repositories/src/CommonRepository.ts
@@ -1,11 +1,12 @@
 import { Snowflake } from 'discord.js';
 
 export interface CommonRepository<T> {
-  insertOne: (entity: T) => Promise<T>;
-  insertMany: (entities: T[]) => Promise<T[]>;
-  findById: (id: Snowflake) => Promise<T | null>;
-  updateOne: (entities: T) => Promise<T>;
-  updateMany: (entities: T[]) => Promise<T[]>;
-  deleteById: (id: Snowflake) => Promise<void>;
-  deleteMany: (entities: T[]) => Promise<void>;
+  insertOne(entity: T): Promise<T>;
+  insertMany(entities: T[]): Promise<T[]>;
+  findById(id: Snowflake): Promise<T | null>;
+  findByIds(ids: Snowflake[]): Promise<T[]>;
+  updateOne(entity: Partial<T>): Promise<T>;
+  updateMany(entities: Partial<T>[]): Promise<T[]>;
+  deleteById(id: Snowflake): Promise<void>;
+  deleteManyByIds(ids: Snowflake[]): Promise<void>;
 }

--- a/packages/repositories/src/cache/BaseCacheRepository.ts
+++ b/packages/repositories/src/cache/BaseCacheRepository.ts
@@ -1,0 +1,37 @@
+import { CommonRepository } from '../CommonRepository';
+import { CacheRepository } from './CacheRepository';
+
+export abstract class BaseCacheRepository<T> {
+  constructor(
+    private cache: CacheRepository<T>,
+    private repository: CommonRepository<T>
+  ) {}
+
+  private async alreadyExists(key: string) {
+    return (
+      (await this.cache.get(key)) != null ||
+      (await this.repository.findById(key)) != null
+    );
+  }
+
+  async set(key: string, data: T): Promise<void> {
+    let instance: T;
+
+    if (await this.alreadyExists(key))
+      instance = await this.repository.updateOne(data);
+    else instance = await this.repository.insertOne(data);
+
+    await this.cache.set(key, instance);
+  }
+
+  async get(key: string): Promise<T | null> {
+    const cached = await this.cache.get(key);
+    if (cached) return cached;
+
+    const instance = await this.repository.findById(key);
+    if (!instance) return null;
+
+    await this.cache.set(key, instance);
+    return instance;
+  }
+}

--- a/packages/repositories/src/cache/CacheManagerRepository.ts
+++ b/packages/repositories/src/cache/CacheManagerRepository.ts
@@ -1,0 +1,18 @@
+import { createCache, CreateCacheOptions } from 'cache-manager';
+import { CacheRepository } from './CacheRepository';
+
+export class CacheManagerRepository<T> implements CacheRepository<T> {
+  private cache: ReturnType<typeof createCache>;
+
+  constructor(options: CreateCacheOptions) {
+    this.cache = createCache(options);
+  }
+
+  async get(key: string): Promise<T | undefined> {
+    return this.cache.get<T>(key);
+  }
+
+  async set(key: string, data: T): Promise<void> {
+    this.cache.set<T>(key, data);
+  }
+}

--- a/packages/repositories/src/cache/CacheRepository.ts
+++ b/packages/repositories/src/cache/CacheRepository.ts
@@ -1,0 +1,4 @@
+export interface CacheRepository<T> {
+  get(key: string): Promise<T | null>;
+  set(key: string, data: T): Promise<void>;
+}

--- a/packages/repositories/src/cache/index.ts
+++ b/packages/repositories/src/cache/index.ts
@@ -1,0 +1,3 @@
+export * from './BaseCacheRepository';
+export * from './CacheManagerRepository';
+export * from './CacheRepository';

--- a/packages/repositories/src/channel/ChannelCacheRepository.ts
+++ b/packages/repositories/src/channel/ChannelCacheRepository.ts
@@ -1,0 +1,4 @@
+import { Channel } from '@zekuru-v2/entities';
+import { BaseCacheRepository } from '../cache/BaseCacheRepository';
+
+export class ChannelCacheRepository extends BaseCacheRepository<Channel> {}

--- a/packages/repositories/src/channel/ChannelMongoRepository.ts
+++ b/packages/repositories/src/channel/ChannelMongoRepository.ts
@@ -1,0 +1,71 @@
+import { Channel } from '@zekuru-v2/entities';
+import { ChannelModel } from '@zekuru-v2/db';
+import { ChannelRepository } from './ChannelRepository';
+import { Snowflake } from 'discord.js';
+import { HydratedDocument } from 'mongoose';
+
+export class ChannelMongoRepository implements ChannelRepository {
+  async insertOne(channel: Channel): Promise<Channel> {
+    const instance = new ChannelModel(channel);
+    await instance.save();
+    return instance;
+  }
+
+  async insertMany(channels: Channel[]): Promise<Channel[]> {
+    const instances = await ChannelModel.insertMany(channels);
+    return instances;
+  }
+
+  async findById(id: Snowflake): Promise<Channel | null> {
+    const instance = await ChannelModel.findById(id);
+    if (!instance) return null;
+    return instance;
+  }
+
+  async findByIds(ids: Snowflake[]): Promise<Channel[]> {
+    const instances = await ChannelModel.find().where('_id').in(ids);
+    return instances;
+  }
+
+  async updateOne(channel: Partial<Channel>): Promise<Channel> {
+    if (channel instanceof ChannelModel) {
+      await channel.save();
+      return channel;
+    }
+
+    const instance = await ChannelModel.findByIdAndUpdate(
+      channel._id,
+      channel,
+      { returnOriginal: false }
+    );
+    return instance;
+  }
+
+  async updateMany(channels: Partial<Channel>[]): Promise<Channel[]> {
+    const map = new Map(channels.map((channel) => [channel._id, channel]));
+    const oldInstances = (await this.findByIds([
+      ...map.keys(),
+    ])) as HydratedDocument<Channel>[];
+
+    // validate first before updating
+    const instances = await Promise.all(
+      oldInstances.map(async (instance) => {
+        instance.set(map.get(instance._id));
+        await instance.validate();
+        return instance;
+      })
+    );
+
+    return await Promise.all(
+      instances.map(async (instance) => await instance.save())
+    );
+  }
+
+  async deleteById(id: Snowflake): Promise<void> {
+    await ChannelModel.deleteOne().where('_id').equals(id);
+  }
+
+  async deleteManyByIds(ids: Snowflake[]): Promise<void> {
+    await ChannelModel.deleteMany().where('_id').in(ids);
+  }
+}

--- a/packages/repositories/src/channel/ChannelMongoRepository.ts
+++ b/packages/repositories/src/channel/ChannelMongoRepository.ts
@@ -1,71 +1,9 @@
 import { Channel } from '@zekuru-v2/entities';
 import { ChannelModel } from '@zekuru-v2/db';
-import { ChannelRepository } from './ChannelRepository';
-import { Snowflake } from 'discord.js';
-import { HydratedDocument } from 'mongoose';
+import { BaseMongoRepository } from '../BaseMongoRepository';
 
-export class ChannelMongoRepository implements ChannelRepository {
-  async insertOne(channel: Channel): Promise<Channel> {
-    const instance = new ChannelModel(channel);
-    await instance.save();
-    return instance;
-  }
-
-  async insertMany(channels: Channel[]): Promise<Channel[]> {
-    const instances = await ChannelModel.insertMany(channels);
-    return instances;
-  }
-
-  async findById(id: Snowflake): Promise<Channel | null> {
-    const instance = await ChannelModel.findById(id);
-    if (!instance) return null;
-    return instance;
-  }
-
-  async findByIds(ids: Snowflake[]): Promise<Channel[]> {
-    const instances = await ChannelModel.find().where('_id').in(ids);
-    return instances;
-  }
-
-  async updateOne(channel: Partial<Channel>): Promise<Channel> {
-    if (channel instanceof ChannelModel) {
-      await channel.save();
-      return channel;
-    }
-
-    const instance = await ChannelModel.findByIdAndUpdate(
-      channel._id,
-      channel,
-      { returnOriginal: false }
-    );
-    return instance;
-  }
-
-  async updateMany(channels: Partial<Channel>[]): Promise<Channel[]> {
-    const map = new Map(channels.map((channel) => [channel._id, channel]));
-    const oldInstances = (await this.findByIds([
-      ...map.keys(),
-    ])) as HydratedDocument<Channel>[];
-
-    // validate first before updating
-    const instances = await Promise.all(
-      oldInstances.map(async (instance) => {
-        instance.set(map.get(instance._id));
-        await instance.validate();
-        return instance;
-      })
-    );
-
-    return await Promise.all(
-      instances.map(async (instance) => await instance.save())
-    );
-  }
-
-  async deleteById(id: Snowflake): Promise<void> {
-    await ChannelModel.deleteOne().where('_id').equals(id);
-  }
-
-  async deleteManyByIds(ids: Snowflake[]): Promise<void> {
-    await ChannelModel.deleteMany().where('_id').in(ids);
+export class ChannelMongoRepository extends BaseMongoRepository<Channel> {
+  constructor() {
+    super(ChannelModel);
   }
 }

--- a/packages/repositories/src/channel/index.ts
+++ b/packages/repositories/src/channel/index.ts
@@ -1,0 +1,3 @@
+export * from './ChannelCacheRepository';
+export * from './ChannelMongoRepository';
+export * from './ChannelRepository';

--- a/packages/repositories/src/guild/GuildCacheRepository.ts
+++ b/packages/repositories/src/guild/GuildCacheRepository.ts
@@ -1,0 +1,4 @@
+import { Guild } from '@zekuru-v2/entities';
+import { BaseCacheRepository } from '../cache/BaseCacheRepository';
+
+export class GuildCacheRepository extends BaseCacheRepository<Guild> {}

--- a/packages/repositories/src/guild/GuildMongoRepository.ts
+++ b/packages/repositories/src/guild/GuildMongoRepository.ts
@@ -1,0 +1,9 @@
+import { Guild } from '@zekuru-v2/entities';
+import { GuildModel } from '@zekuru-v2/db';
+import { BaseMongoRepository } from '../BaseMongoRepository';
+
+export class GuildMongoRepository extends BaseMongoRepository<Guild> {
+  constructor() {
+    super(GuildModel);
+  }
+}

--- a/packages/repositories/src/guild/index.ts
+++ b/packages/repositories/src/guild/index.ts
@@ -1,0 +1,1 @@
+export * from './GuildRepository';

--- a/packages/repositories/src/guild/index.ts
+++ b/packages/repositories/src/guild/index.ts
@@ -1,1 +1,3 @@
+export * from './GuildCacheRepository';
+export * from './GuildMongoRepository';
 export * from './GuildRepository';

--- a/packages/repositories/src/index.ts
+++ b/packages/repositories/src/index.ts
@@ -1,0 +1,5 @@
+export * from './cache';
+export * from './channel';
+export * from './guild';
+export * from './message';
+export * from './CommonRepository';

--- a/packages/repositories/src/message/MessageCacheRepository.ts
+++ b/packages/repositories/src/message/MessageCacheRepository.ts
@@ -1,0 +1,4 @@
+import { Message } from '@zekuru-v2/entities';
+import { BaseCacheRepository } from '../cache/BaseCacheRepository';
+
+export class MessageCacheRepository extends BaseCacheRepository<Message> {}

--- a/packages/repositories/src/message/MessageMongoRepository.ts
+++ b/packages/repositories/src/message/MessageMongoRepository.ts
@@ -1,0 +1,9 @@
+import { Message } from '@zekuru-v2/entities';
+import { MessageModel } from '@zekuru-v2/db';
+import { BaseMongoRepository } from '../BaseMongoRepository';
+
+export class MessageMongoRepository extends BaseMongoRepository<Message> {
+  constructor() {
+    super(MessageModel);
+  }
+}

--- a/packages/repositories/src/message/index.ts
+++ b/packages/repositories/src/message/index.ts
@@ -1,0 +1,1 @@
+export * from './MessageRepository';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1511,6 +1511,13 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@keyv/serialize@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@keyv/serialize/-/serialize-1.0.1.tgz#8dae240d5fe11c589e38b73a2db238dcf26a33cf"
+  integrity sha512-kKXeynfORDGPUEEl2PvTExM2zs+IldC6ZD8jPcfvI351MDNtfMlw9V9s4XZXuJNDK2qR5gbEKxRyoYx3quHUVQ==
+  dependencies:
+    buffer "^6.0.3"
+
 "@mongodb-js/saslprep@^1.1.5":
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz#e974bab8eca9faa88677d4ea4da8d09a52069004"
@@ -2461,6 +2468,21 @@ buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
+cache-manager@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/cache-manager/-/cache-manager-6.3.1.tgz#723ed91489b28b39e8a2a2f3f98aceea57493fd5"
+  integrity sha512-Q8cTcjGzUaTfw/IBOZcUbu0/IUbybOy/+zQO9uluxqFIkfFb/YBZo2HVK8RLRvugeGABzi1vwVctCHQZV2Q2Ww==
+  dependencies:
+    keyv "^5.2.1"
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -3293,7 +3315,7 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ieee754@^1.1.13:
+ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -3910,6 +3932,13 @@ keyv@^4.5.4:
   integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
   dependencies:
     json-buffer "3.0.1"
+
+keyv@^5.2.1:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-5.2.2.tgz#5909eac90c76c4296921d964ab233e5590326bfa"
+  integrity sha512-CRPP4Sq5ofbUE8s4FOirFmDgHeKZFRrH/8+WOUNvLJiMIplRMfnMjxmbaDb+zVd7ex0gGAWqMhZHfcL2u6PrNQ==
+  dependencies:
+    "@keyv/serialize" "^1.0.1"
 
 kleur@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
## Motivation
To streamline database operations and to prevent memory from accumulating using caching with TTL. (Time-To-Live)

## Summary
Implemented repositories and caching for the following entities:
- Channel
- Guild
- Message

There are `BaseCacheRepository<T>` abstract class and `CacheManagerRepository<T>` class to be able to easily create new types of caching. For example, caching webhooks. I didn't create a webhook repository since it pertains to the Zekuru-v2 application directly.

The instances of these caches should be instantiated on the application Zekuru-v2 itself than inside the package.

## Changes
- **MongoDB models**: Created `Guild`, `Channel`, and `Message` models.
- **MongoDB repositories:** Created repositories for the aforementioned models.
- **Cache repositories**: Created caching repositories for the aforementioned models.

## Issues
None.

## Tasks
- [x] Create models for `Channel`, `Guild`, and `Message`.
- [x] Create repositories for those entities.
- [x] Create cache repositories for those entities.